### PR TITLE
display fluid levels in generator GUIs

### DIFF
--- a/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/block/GeneratorBlock.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/block/GeneratorBlock.kt
@@ -4,6 +4,8 @@ import dev.aaronhowser.mods.aaron.misc.AaronExtensions.tell
 import dev.aaronhowser.mods.aaron.block.SimpleContainerBlock
 import dev.aaronhowser.mods.excessive_utilities.block_entity.base.generator.GeneratorBlockEntity
 import dev.aaronhowser.mods.excessive_utilities.block_entity.base.generator.GeneratorType
+import dev.aaronhowser.mods.excessive_utilities.block_entity.generator.ItemAndFluidInputDataDrivenGeneratorBlockEntity
+import dev.aaronhowser.mods.excessive_utilities.block_entity.generator.MagmaticGeneratorBlockEntity
 import dev.aaronhowser.mods.excessive_utilities.block_entity.generator.RainbowGeneratorBlockEntity
 import dev.aaronhowser.mods.excessive_utilities.handler.rainbow_generator.RainbowGeneratorHandler
 import net.minecraft.core.BlockPos
@@ -115,6 +117,9 @@ class GeneratorBlock(
 				if (anyInactive) player.tell(noComponent)
 			}
 
+			return InteractionResult.sidedSuccess(level.isClientSide)
+		} else if (blockEntity is MagmaticGeneratorBlockEntity || blockEntity is ItemAndFluidInputDataDrivenGeneratorBlockEntity) {
+			player.openMenu(blockEntity as MenuProvider) { it.writeBlockPos(pos) }
 			return InteractionResult.sidedSuccess(level.isClientSide)
 		} else if (blockEntity is MenuProvider) {
 			player.openMenu(blockEntity)

--- a/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/block_entity/generator/ItemAndFluidInputDataDrivenGeneratorBlockEntity.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/block_entity/generator/ItemAndFluidInputDataDrivenGeneratorBlockEntity.kt
@@ -11,11 +11,15 @@ import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.core.HolderLookup
 import net.minecraft.nbt.CompoundTag
+import net.minecraft.network.protocol.Packet
+import net.minecraft.network.protocol.game.ClientGamePacketListener
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.entity.player.Inventory
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.inventory.AbstractContainerMenu
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraft.world.level.block.state.BlockState
 import net.neoforged.neoforge.fluids.FluidStack
@@ -36,6 +40,14 @@ open class ItemAndFluidInputDataDrivenGeneratorBlockEntity(
 			override fun isFluidValid(stack: FluidStack): Boolean {
 				val level = level ?: return false
 				return ItemAndFluidFuelRecipe.isValidFluid(stack, specificType.fuelRecipeType, level.recipeManager)
+			}
+
+			override fun onContentsChanged() {
+				setChanged()
+				val level = level ?: return
+				if (!level.isClientSide) {
+					level.sendBlockUpdated(blockPos, blockState, blockState, Block.UPDATE_CLIENTS)
+				}
 			}
 		}
 
@@ -67,7 +79,7 @@ open class ItemAndFluidInputDataDrivenGeneratorBlockEntity(
 	}
 
 	override fun createMenu(containerId: Int, playerInventory: Inventory, player: Player): AbstractContainerMenu {
-		return ItemFluidGeneratorMenu(containerId, playerInventory, container, containerData)
+		return ItemFluidGeneratorMenu(containerId, playerInventory, container, containerData, this)
 	}
 
 	override fun saveAdditional(tag: CompoundTag, registries: HolderLookup.Provider) {
@@ -81,6 +93,9 @@ open class ItemAndFluidInputDataDrivenGeneratorBlockEntity(
 
 		tank.readFromNBT(registries, tag)
 	}
+
+	override fun getUpdateTag(registries: HolderLookup.Provider): CompoundTag = saveWithoutMetadata(registries)
+	override fun getUpdatePacket(): Packet<ClientGamePacketListener> = ClientboundBlockEntityDataPacket.create(this)
 
 	companion object {
 		fun slimy(pos: BlockPos, state: BlockState) = ItemAndFluidInputDataDrivenGeneratorBlockEntity(

--- a/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/block_entity/generator/MagmaticGeneratorBlockEntity.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/block_entity/generator/MagmaticGeneratorBlockEntity.kt
@@ -9,16 +9,19 @@ import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.core.HolderLookup
 import net.minecraft.nbt.CompoundTag
+import net.minecraft.network.protocol.Packet
+import net.minecraft.network.protocol.game.ClientGamePacketListener
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.entity.player.Inventory
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.inventory.AbstractContainerMenu
+import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.state.BlockState
 import net.neoforged.neoforge.fluids.FluidStack
 import net.neoforged.neoforge.fluids.capability.IFluidHandler
 import net.neoforged.neoforge.fluids.capability.templates.FluidTank
 
-//TODO: Placing a bucket in the inventory should empty the bucket and fill the tank
 class MagmaticGeneratorBlockEntity(
 	pos: BlockPos,
 	blockState: BlockState,
@@ -32,6 +35,14 @@ class MagmaticGeneratorBlockEntity(
 				val level = level ?: return false
 				val recipe = MagmaticFuelRecipe.getRecipe(level, stack)
 				return recipe != null
+			}
+
+			override fun onContentsChanged() {
+				setChanged()
+				val level = level ?: return
+				if (!level.isClientSide) {
+					level.sendBlockUpdated(blockPos, blockState, blockState, Block.UPDATE_CLIENTS)
+				}
 			}
 		}
 
@@ -58,7 +69,7 @@ class MagmaticGeneratorBlockEntity(
 	}
 
 	override fun createMenu(containerId: Int, playerInventory: Inventory, player: Player): AbstractContainerMenu {
-		return SingleFluidGeneratorMenu(containerId, playerInventory, container, containerData)
+		return SingleFluidGeneratorMenu(containerId, playerInventory, container, containerData, this)
 	}
 
 	override fun saveAdditional(tag: CompoundTag, registries: HolderLookup.Provider) {
@@ -70,6 +81,9 @@ class MagmaticGeneratorBlockEntity(
 		super.loadAdditional(tag, registries)
 		tank.readFromNBT(registries, tag)
 	}
+
+	override fun getUpdateTag(registries: HolderLookup.Provider): CompoundTag = saveWithoutMetadata(registries)
+	override fun getUpdatePacket(): Packet<ClientGamePacketListener> = ClientboundBlockEntityDataPacket.create(this)
 
 	companion object {
 		fun getFluidCapability(blockEntity: MagmaticGeneratorBlockEntity, direction: Direction?): IFluidHandler {

--- a/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/components/FluidBar.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/components/FluidBar.kt
@@ -1,0 +1,115 @@
+package dev.aaronhowser.mods.excessive_utilities.menu.components
+
+import com.mojang.blaze3d.systems.RenderSystem
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.Font
+import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.client.gui.components.AbstractWidget
+import net.minecraft.client.gui.narration.NarrationElementOutput
+import net.minecraft.network.chat.Component
+import net.minecraft.util.Mth
+import net.minecraft.world.inventory.InventoryMenu
+import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions
+import net.neoforged.neoforge.fluids.FluidStack
+import java.util.function.Supplier
+
+class FluidBar(
+	x: Int,
+	y: Int,
+	val capacityGetter: Supplier<Int>,
+	val fluidGetter: Supplier<FluidStack>,
+	val font: Font
+) : AbstractWidget(x, y, WIDTH, HEIGHT, Component.empty()) {
+
+	override fun renderWidget(
+		guiGraphics: GuiGraphics,
+		mouseX: Int,
+		mouseY: Int,
+		partialTick: Float
+	) {
+		val fluid = fluidGetter.get()
+		val capacity = capacityGetter.get().coerceAtLeast(1)
+
+		if (!fluid.isEmpty) {
+			val percent = (fluid.amount.toFloat() / capacity.toFloat()).coerceIn(0f, 1f)
+			val filledHeight = Mth.ceil(HEIGHT * percent).coerceAtMost(HEIGHT)
+			drawFluid(guiGraphics, fluid, x, y + HEIGHT - filledHeight, WIDTH, filledHeight)
+		}
+
+		if (isHovered) renderTooltip(guiGraphics, mouseX, mouseY)
+	}
+
+	private fun drawFluid(
+		guiGraphics: GuiGraphics,
+		fluid: FluidStack,
+		x: Int,
+		y: Int,
+		width: Int,
+		height: Int
+	) {
+		val extensions = IClientFluidTypeExtensions.of(fluid.fluid)
+		val textureLocation = extensions.getStillTexture(fluid) ?: return
+		val tintColor = extensions.getTintColor(fluid)
+
+		val sprite = Minecraft.getInstance()
+			.getTextureAtlas(InventoryMenu.BLOCK_ATLAS)
+			.apply(textureLocation)
+
+		val r = (tintColor shr 16 and 0xFF) / 255.0f
+		val g = (tintColor shr 8 and 0xFF) / 255.0f
+		val b = (tintColor and 0xFF) / 255.0f
+		val a = ((tintColor shr 24 and 0xFF) / 255.0f).let { if (it == 0.0f) 1.0f else it }
+
+		RenderSystem.enableBlend()
+		RenderSystem.setShaderColor(r, g, b, a)
+
+		val tileSize = 16
+		var drawnHeight = 0
+		while (drawnHeight < height) {
+			val currentTileHeight = (height - drawnHeight).coerceAtMost(tileSize)
+			var drawnWidth = 0
+			while (drawnWidth < width) {
+				val currentTileWidth = (width - drawnWidth).coerceAtMost(tileSize)
+				guiGraphics.blit(
+					x + drawnWidth,
+					y + height - drawnHeight - currentTileHeight,
+					0,
+					currentTileWidth,
+					currentTileHeight,
+					sprite
+				)
+				drawnWidth += currentTileWidth
+			}
+			drawnHeight += currentTileHeight
+		}
+
+		RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f)
+		RenderSystem.disableBlend()
+	}
+
+	private fun renderTooltip(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int) {
+		val fluid = fluidGetter.get()
+		val capacity = capacityGetter.get()
+		val amountString = String.format("%,d", fluid.amount)
+		val capacityString = String.format("%,d", capacity)
+
+		val lines = mutableListOf<Component>()
+		if (fluid.isEmpty) {
+			lines.add(Component.literal("Empty"))
+		} else {
+			lines.add(fluid.hoverName)
+		}
+		lines.add(Component.literal("$amountString / $capacityString mB"))
+
+		guiGraphics.renderComponentTooltip(font, lines, mouseX, mouseY)
+	}
+
+	override fun updateWidgetNarration(narrationElementOutput: NarrationElementOutput) {
+		this.defaultButtonNarrationText(narrationElementOutput)
+	}
+
+	companion object {
+		const val WIDTH = 18
+		const val HEIGHT = 57
+	}
+}

--- a/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/components/FluidBar.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/components/FluidBar.kt
@@ -109,7 +109,7 @@ class FluidBar(
 	}
 
 	companion object {
-		const val WIDTH = 18
-		const val HEIGHT = 57
+		const val WIDTH = 14
+		const val HEIGHT = 29
 	}
 }

--- a/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/item_fluid_generator/ItemFluidGeneratorMenu.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/item_fluid_generator/ItemFluidGeneratorMenu.kt
@@ -3,7 +3,9 @@ package dev.aaronhowser.mods.excessive_utilities.menu.item_fluid_generator
 import dev.aaronhowser.mods.aaron.menu.MenuWithInventory
 import dev.aaronhowser.mods.excessive_utilities.block_entity.base.generator.GeneratorBlockEntity
 import dev.aaronhowser.mods.excessive_utilities.block_entity.base.generator.GeneratorContainer
+import dev.aaronhowser.mods.excessive_utilities.block_entity.generator.ItemAndFluidInputDataDrivenGeneratorBlockEntity
 import dev.aaronhowser.mods.excessive_utilities.registry.ModMenuTypes
+import net.minecraft.network.RegistryFriendlyByteBuf
 import net.minecraft.world.Container
 import net.minecraft.world.SimpleContainer
 import net.minecraft.world.entity.player.Inventory
@@ -17,16 +19,9 @@ class ItemFluidGeneratorMenu(
 	containerId: Int,
 	playerInventory: Inventory,
 	val generatorContainer: Container,
-	val generatorContainerData: ContainerData
+	val generatorContainerData: ContainerData,
+	val blockEntity: ItemAndFluidInputDataDrivenGeneratorBlockEntity?
 ) : MenuWithInventory(ModMenuTypes.ITEM_FLUID_GENERATOR.get(), containerId, playerInventory) {
-
-	constructor(containerId: Int, playerInventory: Inventory) :
-			this(
-				containerId,
-				playerInventory,
-				SimpleContainer(CONTAINER_SIZE),
-				SimpleContainerData(GeneratorBlockEntity.DEFAULT_GENERATOR_CONTAINER_DATA_SIZE)
-			)
 
 	init {
 		checkContainerSize(generatorContainer, CONTAINER_SIZE)
@@ -43,7 +38,7 @@ class ItemFluidGeneratorMenu(
 
 	override fun addSlots() {
 		val upgradeSlot = Slot(generatorContainer, GeneratorContainer.UPGRADE_SLOT, 153, 5)
-		val inputSlots = Slot(generatorContainer, GeneratorContainer.INPUT_SLOT, 47, 46)
+		val inputSlots = Slot(generatorContainer, GeneratorContainer.INPUT_SLOT, 68, 46)
 
 		this.addSlot(upgradeSlot)
 		this.addSlot(inputSlots)
@@ -59,5 +54,22 @@ class ItemFluidGeneratorMenu(
 
 	companion object {
 		const val CONTAINER_SIZE = 2
+
+		fun fromNetwork(
+			containerId: Int,
+			playerInventory: Inventory,
+			data: RegistryFriendlyByteBuf
+		): ItemFluidGeneratorMenu {
+			val pos = data.readBlockPos()
+			val be = playerInventory.player.level().getBlockEntity(pos) as? ItemAndFluidInputDataDrivenGeneratorBlockEntity
+
+			return ItemFluidGeneratorMenu(
+				containerId,
+				playerInventory,
+				SimpleContainer(CONTAINER_SIZE),
+				SimpleContainerData(GeneratorBlockEntity.DEFAULT_GENERATOR_CONTAINER_DATA_SIZE),
+				be
+			)
+		}
 	}
 }

--- a/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/item_fluid_generator/ItemFluidGeneratorScreen.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/item_fluid_generator/ItemFluidGeneratorScreen.kt
@@ -4,10 +4,11 @@ import dev.aaronhowser.mods.aaron.menu.BaseScreen
 import dev.aaronhowser.mods.aaron.menu.textures.ScreenBackground
 import dev.aaronhowser.mods.excessive_utilities.ExcessiveUtilities
 import dev.aaronhowser.mods.excessive_utilities.menu.components.EnergyBar
+import dev.aaronhowser.mods.excessive_utilities.menu.components.FluidBar
 import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.player.Inventory
+import net.neoforged.neoforge.fluids.FluidStack
 
-//TODO: Render the fluid
 class ItemFluidGeneratorScreen(
 	menu: ItemFluidGeneratorMenu,
 	playerInventory: Inventory,
@@ -19,6 +20,7 @@ class ItemFluidGeneratorScreen(
 		get() = 10
 
 	private lateinit var energyBar: EnergyBar
+	private lateinit var fluidBar: FluidBar
 
 	override fun baseInit() {
 		super.baseInit()
@@ -31,7 +33,16 @@ class ItemFluidGeneratorScreen(
 			font = font
 		)
 
+		fluidBar = FluidBar(
+			x = leftPos + 44,
+			y = topPos + 18,
+			capacityGetter = { menu.blockEntity?.tank?.capacity ?: 0 },
+			fluidGetter = { menu.blockEntity?.tank?.fluid ?: FluidStack.EMPTY },
+			font = font
+		)
+
 		addRenderableWidget(energyBar)
+		addRenderableWidget(fluidBar)
 	}
 
 	companion object {

--- a/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/item_fluid_generator/ItemFluidGeneratorScreen.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/item_fluid_generator/ItemFluidGeneratorScreen.kt
@@ -34,8 +34,8 @@ class ItemFluidGeneratorScreen(
 		)
 
 		fluidBar = FluidBar(
-			x = leftPos + 44,
-			y = topPos + 18,
+			x = leftPos + 69,
+			y = topPos + 40,
 			capacityGetter = { menu.blockEntity?.tank?.capacity ?: 0 },
 			fluidGetter = { menu.blockEntity?.tank?.fluid ?: FluidStack.EMPTY },
 			font = font

--- a/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/single_fluid_generator/SingleFluidGeneratorMenu.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/single_fluid_generator/SingleFluidGeneratorMenu.kt
@@ -3,7 +3,9 @@ package dev.aaronhowser.mods.excessive_utilities.menu.single_fluid_generator
 import dev.aaronhowser.mods.aaron.menu.MenuWithInventory
 import dev.aaronhowser.mods.excessive_utilities.block_entity.base.generator.GeneratorBlockEntity
 import dev.aaronhowser.mods.excessive_utilities.block_entity.base.generator.GeneratorContainer
+import dev.aaronhowser.mods.excessive_utilities.block_entity.generator.MagmaticGeneratorBlockEntity
 import dev.aaronhowser.mods.excessive_utilities.registry.ModMenuTypes
+import net.minecraft.network.RegistryFriendlyByteBuf
 import net.minecraft.world.Container
 import net.minecraft.world.SimpleContainer
 import net.minecraft.world.entity.player.Inventory
@@ -17,16 +19,9 @@ class SingleFluidGeneratorMenu(
 	containerId: Int,
 	playerInventory: Inventory,
 	val generatorContainer: Container,
-	val generatorContainerData: ContainerData
+	val generatorContainerData: ContainerData,
+	val blockEntity: MagmaticGeneratorBlockEntity?
 ) : MenuWithInventory(ModMenuTypes.SINGLE_FLUID_GENERATOR.get(), containerId, playerInventory) {
-
-	constructor(containerId: Int, playerInventory: Inventory) :
-			this(
-				containerId,
-				playerInventory,
-				SimpleContainer(CONTAINER_SIZE),
-				SimpleContainerData(GeneratorBlockEntity.DEFAULT_GENERATOR_CONTAINER_DATA_SIZE)
-			)
 
 	init {
 		checkContainerSize(generatorContainer, CONTAINER_SIZE)
@@ -57,5 +52,22 @@ class SingleFluidGeneratorMenu(
 
 	companion object {
 		const val CONTAINER_SIZE = 2
+
+		fun fromNetwork(
+			containerId: Int,
+			playerInventory: Inventory,
+			data: RegistryFriendlyByteBuf
+		): SingleFluidGeneratorMenu {
+			val pos = data.readBlockPos()
+			val be = playerInventory.player.level().getBlockEntity(pos) as? MagmaticGeneratorBlockEntity
+
+			return SingleFluidGeneratorMenu(
+				containerId,
+				playerInventory,
+				SimpleContainer(CONTAINER_SIZE),
+				SimpleContainerData(GeneratorBlockEntity.DEFAULT_GENERATOR_CONTAINER_DATA_SIZE),
+				be
+			)
+		}
 	}
 }

--- a/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/single_fluid_generator/SingleFluidGeneratorScreen.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/single_fluid_generator/SingleFluidGeneratorScreen.kt
@@ -34,8 +34,8 @@ class SingleFluidGeneratorScreen(
 		)
 
 		fluidBar = FluidBar(
-			x = leftPos + 44,
-			y = topPos + 18,
+			x = leftPos + 69,
+			y = topPos + 40,
 			capacityGetter = { menu.blockEntity?.tank?.capacity ?: 0 },
 			fluidGetter = { menu.blockEntity?.tank?.fluid ?: FluidStack.EMPTY },
 			font = font

--- a/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/single_fluid_generator/SingleFluidGeneratorScreen.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/menu/single_fluid_generator/SingleFluidGeneratorScreen.kt
@@ -4,8 +4,10 @@ import dev.aaronhowser.mods.aaron.menu.BaseScreen
 import dev.aaronhowser.mods.aaron.menu.textures.ScreenBackground
 import dev.aaronhowser.mods.excessive_utilities.ExcessiveUtilities
 import dev.aaronhowser.mods.excessive_utilities.menu.components.EnergyBar
+import dev.aaronhowser.mods.excessive_utilities.menu.components.FluidBar
 import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.player.Inventory
+import net.neoforged.neoforge.fluids.FluidStack
 
 class SingleFluidGeneratorScreen(
 	menu: SingleFluidGeneratorMenu,
@@ -18,6 +20,7 @@ class SingleFluidGeneratorScreen(
 		get() = 10
 
 	private lateinit var energyBar: EnergyBar
+	private lateinit var fluidBar: FluidBar
 
 	override fun baseInit() {
 		super.baseInit()
@@ -30,7 +33,16 @@ class SingleFluidGeneratorScreen(
 			font = font
 		)
 
+		fluidBar = FluidBar(
+			x = leftPos + 44,
+			y = topPos + 18,
+			capacityGetter = { menu.blockEntity?.tank?.capacity ?: 0 },
+			fluidGetter = { menu.blockEntity?.tank?.fluid ?: FluidStack.EMPTY },
+			font = font
+		)
+
 		addRenderableWidget(energyBar)
+		addRenderableWidget(fluidBar)
 	}
 
 	companion object {

--- a/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/registry/ModMenuTypes.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/excessive_utilities/registry/ModMenuTypes.kt
@@ -63,9 +63,9 @@ object ModMenuTypes : AaronMenuTypesRegistry() {
 	val SINGLE_ITEM_GENERATOR: DeferredHolder<MenuType<*>, MenuType<SingleItemGeneratorMenu>> =
 		register("single_item_generator", ::SingleItemGeneratorMenu)
 	val SINGLE_FLUID_GENERATOR: DeferredHolder<MenuType<*>, MenuType<SingleFluidGeneratorMenu>> =
-		register("single_fluid_generator", ::SingleFluidGeneratorMenu)
+		register("single_fluid_generator") { IMenuTypeExtension.create(SingleFluidGeneratorMenu::fromNetwork) }
 	val ITEM_FLUID_GENERATOR: DeferredHolder<MenuType<*>, MenuType<ItemFluidGeneratorMenu>> =
-		register("item_fluid_generator", ::ItemFluidGeneratorMenu)
+		register("item_fluid_generator") { IMenuTypeExtension.create(ItemFluidGeneratorMenu::fromNetwork) }
 	val QED: DeferredHolder<MenuType<*>, MenuType<QedMenu>> =
 		register("qed", ::QedMenu)
 	val SIMPLE_MACHINE: DeferredHolder<MenuType<*>, MenuType<SimpleMachineMenu>> =


### PR DESCRIPTION
Adds a FluidBar UI component and implements client-side data syncing for Magmatic and Item/Fluid generators.
Fixes: https://github.com/Berry-Club/Excessive-Utilities/issues/20